### PR TITLE
Changed content-length to include white space when pretty printing

### DIFF
--- a/client-testsuite/responses-v2/actionset-echo-complex-types-union.res
+++ b/client-testsuite/responses-v2/actionset-echo-complex-types-union.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 59
+Content-Length: 89
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-echo-message-array.res
+++ b/client-testsuite/responses-v2/actionset-echo-message-array.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 68
+Content-Length: 97
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-echo-message.res
+++ b/client-testsuite/responses-v2/actionset-echo-message.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 36
+Content-Length: 52
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-echo-primitive-union.res
+++ b/client-testsuite/responses-v2/actionset-echo-primitive-union.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 42
+Content-Length: 72
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-echo-string-array.res
+++ b/client-testsuite/responses-v2/actionset-echo-string-array.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 37
+Content-Length: 46
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-echo-string-map.res
+++ b/client-testsuite/responses-v2/actionset-echo-string-map.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 49
+Content-Length: 72
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-echo-typeref-url.res
+++ b/client-testsuite/responses-v2/actionset-echo-typeref-url.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 26
+Content-Length: 32
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-echo.res
+++ b/client-testsuite/responses-v2/actionset-echo.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 33
+Content-Length: 39
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-multiple-inputs-no-optional.res
+++ b/client-testsuite/responses-v2/actionset-multiple-inputs-no-optional.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 14
+Content-Length: 20
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-multiple-inputs.res
+++ b/client-testsuite/responses-v2/actionset-multiple-inputs.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 14
+Content-Length: 20
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-return-bool.res
+++ b/client-testsuite/responses-v2/actionset-return-bool.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 14
+Content-Length: 20
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/actionset-return-int.res
+++ b/client-testsuite/responses-v2/actionset-return-int.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 12
+Content-Length: 18
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/association-assoc-key-finder.res
+++ b/client-testsuite/responses-v2/association-assoc-key-finder.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 318
+Content-Length: 547
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/association-batch-delete.res
+++ b/client-testsuite/responses-v2/association-batch-delete.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 125
+Content-Length: 182
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/association-batch-get.res
+++ b/client-testsuite/responses-v2/association-batch-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 285
+Content-Length: 482
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/association-batch-update.res
+++ b/client-testsuite/responses-v2/association-batch-update.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 125
+Content-Length: 182
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/association-get.res
+++ b/client-testsuite/responses-v2/association-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 87
+Content-Length: 132
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/association-typeref-get.res
+++ b/client-testsuite/responses-v2/association-typeref-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 26
+Content-Length: 32
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-batch-create.res
+++ b/client-testsuite/responses-v2/collection-batch-create.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 116
+Content-Length: 173
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-batch-delete.res
+++ b/client-testsuite/responses-v2/collection-batch-delete.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 63
+Content-Length: 120
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-batch-get.res
+++ b/client-testsuite/responses-v2/collection-batch-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 118
+Content-Length: 199
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-batch-partial-update.res
+++ b/client-testsuite/responses-v2/collection-batch-partial-update.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 63
+Content-Length: 120
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-batch-update-errors.res
+++ b/client-testsuite/responses-v2/collection-batch-update-errors.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 8360
+Content-Length: 8485
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-batch-update.res
+++ b/client-testsuite/responses-v2/collection-batch-update.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 63
+Content-Length: 120
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-create-500.res
+++ b/client-testsuite/responses-v2/collection-create-500.res
@@ -1,5 +1,5 @@
 HTTP/1.1 500 Internal Server Error
-Content-Length: 4271
+Content-Length: 4292
 Content-Type: application/json
 X-RestLi-Error-Response: true
 X-RestLi-Protocol-Version: 2.0.0

--- a/client-testsuite/responses-v2/collection-create-error-details.res
+++ b/client-testsuite/responses-v2/collection-create-error-details.res
@@ -1,5 +1,5 @@
 HTTP/1.1 400 Bad Request
-Content-Length: 4130
+Content-Length: 4173
 Content-Type: application/json
 X-RestLi-Error-Response: true
 X-RestLi-Protocol-Version: 2.0.0

--- a/client-testsuite/responses-v2/collection-get-404.res
+++ b/client-testsuite/responses-v2/collection-get-404.res
@@ -1,5 +1,5 @@
 HTTP/1.1 404 Not Found
-Content-Length: 4182
+Content-Length: 4203
 Content-Type: application/json
 X-RestLi-Error-Response: true
 X-RestLi-Protocol-Version: 2.0.0

--- a/client-testsuite/responses-v2/collection-get-projection.res
+++ b/client-testsuite/responses-v2/collection-get-projection.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 8
+Content-Length: 14
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-get.res
+++ b/client-testsuite/responses-v2/collection-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 33
+Content-Length: 44
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-search-finder.res
+++ b/client-testsuite/responses-v2/collection-search-finder.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 196
+Content-Length: 298
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-typeref-get.res
+++ b/client-testsuite/responses-v2/collection-typeref-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 26
+Content-Length: 32
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/collection-update-400.res
+++ b/client-testsuite/responses-v2/collection-update-400.res
@@ -1,5 +1,5 @@
 HTTP/1.1 400 Bad Request
-Content-Length: 4116
+Content-Length: 4137
 Content-Type: application/json
 X-RestLi-Error-Response: true
 X-RestLi-Protocol-Version: 2.0.0

--- a/client-testsuite/responses-v2/collectionReturnEntity-create.res
+++ b/client-testsuite/responses-v2/collectionReturnEntity-create.res
@@ -1,5 +1,5 @@
 HTTP/1.1 201 Created
-Content-Length: 26
+Content-Length: 32
 Content-Type: application/json
 Location: /collectionReturnEntity/1
 X-RestLi-Id: 1

--- a/client-testsuite/responses-v2/complexkey-batch-create.res
+++ b/client-testsuite/responses-v2/complexkey-batch-create.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 44
+Content-Length: 73
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/complexkey-batch-delete.res
+++ b/client-testsuite/responses-v2/complexkey-batch-delete.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 124
+Content-Length: 181
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/complexkey-batch-get-with-special-chars.res
+++ b/client-testsuite/responses-v2/complexkey-batch-get-with-special-chars.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 333
+Content-Length: 530
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/complexkey-batch-get.res
+++ b/client-testsuite/responses-v2/complexkey-batch-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 283
+Content-Length: 480
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/complexkey-batch-update.res
+++ b/client-testsuite/responses-v2/complexkey-batch-update.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 124
+Content-Length: 181
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/complexkey-get-projection.res
+++ b/client-testsuite/responses-v2/complexkey-get-projection.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 14
+Content-Length: 21
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/complexkey-get-with-special-chars.res
+++ b/client-testsuite/responses-v2/complexkey-get-with-special-chars.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 106
+Content-Length: 151
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/complexkey-get.res
+++ b/client-testsuite/responses-v2/complexkey-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 86
+Content-Length: 131
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/keywithunion-get.res
+++ b/client-testsuite/responses-v2/keywithunion-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 86
+Content-Length: 131
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/params-get-with-queryparams.res
+++ b/client-testsuite/responses-v2/params-get-with-queryparams.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 33
+Content-Length: 44
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/simple-get.res
+++ b/client-testsuite/responses-v2/simple-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 26
+Content-Length: 32
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/sub-collection-of-collection-get.res
+++ b/client-testsuite/responses-v2/sub-collection-of-collection-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 45
+Content-Length: 56
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses-v2/sub-simple-of-collection-get.res
+++ b/client-testsuite/responses-v2/sub-simple-of-collection-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 32
+Content-Length: 38
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 

--- a/client-testsuite/responses/actionset-echo-complex-types-union.res
+++ b/client-testsuite/responses/actionset-echo-complex-types-union.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 59
+Content-Length: 89
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-echo-message-array.res
+++ b/client-testsuite/responses/actionset-echo-message-array.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 68
+Content-Length: 97
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-echo-message.res
+++ b/client-testsuite/responses/actionset-echo-message.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 36
+Content-Length: 52
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-echo-primitive-union.res
+++ b/client-testsuite/responses/actionset-echo-primitive-union.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 42
+Content-Length: 72
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-echo-string-array.res
+++ b/client-testsuite/responses/actionset-echo-string-array.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 37
+Content-Length: 46
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-echo-string-map.res
+++ b/client-testsuite/responses/actionset-echo-string-map.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 49
+Content-Length: 72
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-echo-typeref-url.res
+++ b/client-testsuite/responses/actionset-echo-typeref-url.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 26
+Content-Length: 32
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-echo.res
+++ b/client-testsuite/responses/actionset-echo.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 33
+Content-Length: 39
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-multiple-inputs-no-optional.res
+++ b/client-testsuite/responses/actionset-multiple-inputs-no-optional.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 14
+Content-Length: 20
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-multiple-inputs.res
+++ b/client-testsuite/responses/actionset-multiple-inputs.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 14
+Content-Length: 20
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-return-bool.res
+++ b/client-testsuite/responses/actionset-return-bool.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 14
+Content-Length: 20
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/actionset-return-int.res
+++ b/client-testsuite/responses/actionset-return-int.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 12
+Content-Length: 18
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/association-assoc-key-finder.res
+++ b/client-testsuite/responses/association-assoc-key-finder.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 318
+Content-Length: 547
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/association-batch-delete.res
+++ b/client-testsuite/responses/association-batch-delete.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 121
+Content-Length: 178
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/association-batch-get.res
+++ b/client-testsuite/responses/association-batch-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 281
+Content-Length: 478
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/association-batch-update.res
+++ b/client-testsuite/responses/association-batch-update.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 121
+Content-Length: 178
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/association-get.res
+++ b/client-testsuite/responses/association-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 87
+Content-Length: 132
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/association-typeref-get.res
+++ b/client-testsuite/responses/association-typeref-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 26
+Content-Length: 32
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-batch-create.res
+++ b/client-testsuite/responses/collection-batch-create.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 116
+Content-Length: 173
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-batch-delete.res
+++ b/client-testsuite/responses/collection-batch-delete.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 63
+Content-Length: 120
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-batch-get.res
+++ b/client-testsuite/responses/collection-batch-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 118
+Content-Length: 199
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-batch-partial-update.res
+++ b/client-testsuite/responses/collection-batch-partial-update.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 63
+Content-Length: 120
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-batch-update-errors.res
+++ b/client-testsuite/responses/collection-batch-update-errors.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 8360
+Content-Length: 8485
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-batch-update.res
+++ b/client-testsuite/responses/collection-batch-update.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 63
+Content-Length: 120
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-create-500.res
+++ b/client-testsuite/responses/collection-create-500.res
@@ -1,5 +1,5 @@
 HTTP/1.1 500 Internal Server Error
-Content-Length: 4271
+Content-Length: 4292
 Content-Type: application/json
 X-LinkedIn-Error-Response: true
 X-RestLi-Protocol-Version: 1.0.0

--- a/client-testsuite/responses/collection-create-error-details.res
+++ b/client-testsuite/responses/collection-create-error-details.res
@@ -1,5 +1,5 @@
 HTTP/1.1 400 Bad Request
-Content-Length: 4130
+Content-Length: 4173
 Content-Type: application/json
 X-LinkedIn-Error-Response: true
 X-RestLi-Protocol-Version: 1.0.0

--- a/client-testsuite/responses/collection-get-404.res
+++ b/client-testsuite/responses/collection-get-404.res
@@ -1,5 +1,5 @@
 HTTP/1.1 404 Not Found
-Content-Length: 4182
+Content-Length: 4203
 Content-Type: application/json
 X-LinkedIn-Error-Response: true
 X-RestLi-Protocol-Version: 1.0.0

--- a/client-testsuite/responses/collection-get-projection.res
+++ b/client-testsuite/responses/collection-get-projection.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 8
+Content-Length: 14
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-get.res
+++ b/client-testsuite/responses/collection-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 33
+Content-Length: 44
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-search-finder.res
+++ b/client-testsuite/responses/collection-search-finder.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 196
+Content-Length: 298
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-typeref-get.res
+++ b/client-testsuite/responses/collection-typeref-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 26
+Content-Length: 32
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/collection-update-400.res
+++ b/client-testsuite/responses/collection-update-400.res
@@ -1,5 +1,5 @@
 HTTP/1.1 400 Bad Request
-Content-Length: 4116
+Content-Length: 4137
 Content-Type: application/json
 X-LinkedIn-Error-Response: true
 X-RestLi-Protocol-Version: 1.0.0

--- a/client-testsuite/responses/collectionReturnEntity-create.res
+++ b/client-testsuite/responses/collectionReturnEntity-create.res
@@ -1,5 +1,5 @@
 HTTP/1.1 201 Created
-Content-Length: 26
+Content-Length: 32
 Content-Type: application/json
 Location: /collectionReturnEntity/1
 X-LinkedIn-Id: 1

--- a/client-testsuite/responses/complexkey-batch-create.res
+++ b/client-testsuite/responses/complexkey-batch-create.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 44
+Content-Length: 73
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/complexkey-batch-delete.res
+++ b/client-testsuite/responses/complexkey-batch-delete.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 120
+Content-Length: 177
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/complexkey-batch-get-with-special-chars.res
+++ b/client-testsuite/responses/complexkey-batch-get-with-special-chars.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 355
+Content-Length: 552
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/complexkey-batch-get.res
+++ b/client-testsuite/responses/complexkey-batch-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 279
+Content-Length: 476
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/complexkey-batch-update.res
+++ b/client-testsuite/responses/complexkey-batch-update.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 120
+Content-Length: 177
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/complexkey-get-projection.res
+++ b/client-testsuite/responses/complexkey-get-projection.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 14
+Content-Length: 21
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/complexkey-get-with-special-chars.res
+++ b/client-testsuite/responses/complexkey-get-with-special-chars.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 106
+Content-Length: 151
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/complexkey-get.res
+++ b/client-testsuite/responses/complexkey-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 86
+Content-Length: 131
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/keywithunion-get.res
+++ b/client-testsuite/responses/keywithunion-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 86
+Content-Length: 131
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/params-get-with-queryparams.res
+++ b/client-testsuite/responses/params-get-with-queryparams.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 33
+Content-Length: 44
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/simple-get.res
+++ b/client-testsuite/responses/simple-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 26
+Content-Length: 32
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/sub-collection-of-collection-get.res
+++ b/client-testsuite/responses/sub-collection-of-collection-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 45
+Content-Length: 56
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/responses/sub-simple-of-collection-get.res
+++ b/client-testsuite/responses/sub-simple-of-collection-get.res
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Content-Length: 32
+Content-Length: 38
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 

--- a/client-testsuite/src/test/java/com/linkedin/pegasus/testsuite/TestSuiteMessageSerializer.java
+++ b/client-testsuite/src/test/java/com/linkedin/pegasus/testsuite/TestSuiteMessageSerializer.java
@@ -91,13 +91,14 @@ public class TestSuiteMessageSerializer extends DefaultMessageSerializer
     RestResponseBuilder builder = res.builder();
     Map<String, String> headers = new HashMap<String, String>(builder.getHeaders());
     headers.remove("Server");
-    builder.setHeaders(headers);
 
     if(res.getEntity().length() > 0)
     {
       builder.setEntity(CODEC.mapToBytes(DataMapUtils.readMap(res)));
     }
 
+    headers.put("Content-Length", Integer.toString(builder.getEntity().length()));
+    builder.setHeaders(headers);
     return builder.build();
   }
 


### PR DESCRIPTION
Calculate content-length header after formatting the response with whitespace. This addresses  https://github.com/linkedin/rest.li-test-suite/issues/2.