### PR TITLE
Return correct ComplexResourceKey from ComplexKeyResource CREATE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+mainGeneratedDataTemplate/
+mainGeneratedRest/
+out/

--- a/client-testsuite/responses-v2/complexkey-batch-create.res
+++ b/client-testsuite/responses-v2/complexkey-batch-create.res
@@ -1,12 +1,16 @@
 HTTP/1.1 200 OK
-Content-Length: 73
+Content-Length: 295
 Content-Type: application/json
 X-RestLi-Protocol-Version: 2.0.0
 
 {
   "elements" : [ {
+    "location" : "/complexkey/(part1:one,part2:2,part3:APPLE)",
+    "id" : "(part1:one,part2:2,part3:APPLE)",
     "status" : 201
   }, {
+    "location" : "/complexkey/(part1:two,part2:7,part3:ORANGE)",
+    "id" : "(part1:two,part2:7,part3:ORANGE)",
     "status" : 201
   } ]
 }

--- a/client-testsuite/responses-v2/complexkey-create.res
+++ b/client-testsuite/responses-v2/complexkey-create.res
@@ -1,5 +1,7 @@
 HTTP/1.1 201 Created
 Content-Length: 0
+Location: /complexkey/(part1:one,part2:2,part3:APPLE)
+X-RestLi-Id: (part1:one,part2:2,part3:APPLE)
 X-RestLi-Protocol-Version: 2.0.0
 
 

--- a/client-testsuite/responses/complexkey-batch-create.res
+++ b/client-testsuite/responses/complexkey-batch-create.res
@@ -1,12 +1,16 @@
 HTTP/1.1 200 OK
-Content-Length: 73
+Content-Length: 287
 Content-Type: application/json
 X-RestLi-Protocol-Version: 1.0.0
 
 {
   "elements" : [ {
+    "location" : "/complexkey/part1=one&part2=2&part3=APPLE",
+    "id" : "part1=one&part2=2&part3=APPLE",
     "status" : 201
   }, {
+    "location" : "/complexkey/part1=two&part2=7&part3=ORANGE",
+    "id" : "part1=two&part2=7&part3=ORANGE",
     "status" : 201
   } ]
 }

--- a/client-testsuite/responses/complexkey-create.res
+++ b/client-testsuite/responses/complexkey-create.res
@@ -1,5 +1,7 @@
 HTTP/1.1 201 Created
 Content-Length: 0
+Location: /complexkey/part1=one&part2=2&part3=APPLE
+X-LinkedIn-Id: part1=one&part2=2&part3=APPLE
 X-RestLi-Protocol-Version: 1.0.0
 
 

--- a/client-testsuite/src/test/java/com/linkedin/pegasus/test/TestRestClientWithManualAssertions.java
+++ b/client-testsuite/src/test/java/com/linkedin/pegasus/test/TestRestClientWithManualAssertions.java
@@ -9,8 +9,10 @@ import com.linkedin.restli.client.Response;
 import com.linkedin.restli.client.response.BatchKVResponse;
 import com.linkedin.restli.common.BatchResponse;
 import com.linkedin.restli.common.CollectionResponse;
+import com.linkedin.restli.common.ComplexResourceKey;
 import com.linkedin.restli.common.EmptyRecord;
 import com.linkedin.restli.common.ErrorResponse;
+import com.linkedin.restli.common.IdResponse;
 import com.linkedin.restli.common.LinkArray;
 import com.linkedin.restli.common.UpdateStatus;
 import java.io.File;
@@ -24,6 +26,10 @@ import testsuite.Message;
 import testsuite.MessageArray;
 import testsuite.UnionOfComplexTypes;
 import testsuite.UnionOfPrimitives;
+import testsuite.complexkey.ComplexKey;
+import testsuite.complexkey.KeyParams;
+
+
 /**
  * This test suite supplementary to the manifest driven tests run by TestRestClientAgainstStandardTestSuite.
  *
@@ -377,6 +383,17 @@ public class TestRestClientWithManualAssertions extends StandardTestSuiteBase
     Assert.assertEquals(response.getEntity().getKey().getPart2(), Long.valueOf(2l));
     Assert.assertEquals(response.getEntity().getKey().getPart3(), Fruits.APPLE);
     Assert.assertEquals(response.getEntity().getMessage().getMessage(), "test message");
+  }
+
+  @Test(dataProvider = "dp")
+  public void testComplexKeyCreate(String version) throws Exception
+  {
+    Response<IdResponse<ComplexResourceKey<ComplexKey, KeyParams>>> response =
+        loadResponse(version, "complexkey-create");
+    ComplexKey key = response.getEntity().getId().getKey();
+    Assert.assertEquals(key.getPart1(), "one");
+    Assert.assertEquals(key.getPart2(), Long.valueOf(2l));
+    Assert.assertEquals(key.getPart3(), Fruits.APPLE);
   }
 
   @Test(dataProvider = "dp")

--- a/restli-testsuite-server/src/main/java/testsuite/ComplexKeyResource.java
+++ b/restli-testsuite-server/src/main/java/testsuite/ComplexKeyResource.java
@@ -120,12 +120,9 @@ public class ComplexKeyResource extends ComplexKeyResourceTemplate<ComplexKey, K
   public CreateResponse create(LargeRecord entity)
   {
     return new CreateResponse(
-
-        /*new ComplexKey()
-            .setPart1("one")
-            .setPart2(2l)
-            .setPart3(Fruits.APPLE),*/
-        HttpStatus.S_201_CREATED);
+        new ComplexResourceKey<ComplexKey, KeyParams>(entity.getKey(), null),
+        HttpStatus.S_201_CREATED
+    );
   }
 
   @Override


### PR DESCRIPTION
This will set the Location header for CREATE and the right fields in the BATCH_CREATE response to
allow proper testing of complex key deserialization.